### PR TITLE
feat: add quote generation CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,62 @@
-# bg
-Báo giá Huy Hoàng2
+# Ứng dụng tạo báo giá
+
+Ứng dụng dòng lệnh hỗ trợ đọc danh sách sản phẩm từ Excel và xuất báo giá PDF với mẫu được định dạng bằng HTML/CSS.
+
+## Cài đặt
+
+1. Tạo và kích hoạt môi trường ảo (khuyến nghị):
+
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate  # Trên Windows: .venv\\Scripts\\activate
+   ```
+
+2. Cài đặt các thư viện cần thiết:
+
+   ```bash
+   pip install pandas jinja2 weasyprint
+   ```
+
+   > **Lưu ý:** WeasyPrint phụ thuộc vào một số thư viện hệ thống (GTK, Pango, Cairo…). Tham khảo tài liệu chính thức của [WeasyPrint](https://doc.courtbouillon.org/weasyprint/stable/first_steps.html#installation) để chuẩn bị môi trường tương ứng với hệ điều hành của bạn.
+
+## Chuẩn bị dữ liệu Excel
+
+File Excel cần chứa ít nhất các cột sau:
+
+- `code`: Mã sản phẩm.
+- `name`: Tên hoặc mô tả sản phẩm.
+- `unit_price`: Đơn giá (số).
+
+Có thể bổ sung thêm các cột tùy chọn như `unit` (đơn vị tính), `description` (mô tả chi tiết) hay các cột khác. Ứng dụng sẽ tự động đưa các trường có sẵn vào báo giá.
+
+Ví dụ tối giản trong Excel:
+
+| code | name                | unit_price | unit | description        |
+|------|---------------------|------------|------|--------------------|
+| SP01 | Máy in laser A4     | 3200000    | bộ  | Bảo hành 12 tháng |
+| SP02 | Giấy in A4 80gsm    | 55000      | ram |                    |
+
+## Tạo báo giá
+
+Sau khi có file Excel (ví dụ `data.xlsx`), chạy lệnh:
+
+```bash
+python -m quote_app \
+  --input data.xlsx \
+  --output bao_gia.pdf \
+  --customer "Công ty TNHH XYZ" \
+  --items SP01:2 SP02:10 \
+  --note "Giá đã bao gồm chi phí vận chuyển nội thành." \
+  --tax-rate 8
+```
+
+Các tuỳ chọn hữu ích khác:
+
+- `--customer-company`, `--customer-address`: Bổ sung thông tin khách hàng.
+- `--company-name`, `--company-address`, `--company-phone`, `--company-email`, `--company-website`, `--company-tax-code`: Tùy biến thông tin công ty phát hành báo giá.
+- `--logo`: Chỉ định đường dẫn logo (định dạng PNG/SVG/JPG) để hiển thị trong báo giá.
+- `--template-file`: Sử dụng mẫu HTML tùy chỉnh (Jinja2). Nếu không cung cấp, ứng dụng dùng mẫu mặc định trong mã nguồn.
+- `--currency-symbol`: Đổi ký hiệu tiền tệ hiển thị.
+- `--footer`: Thêm ghi chú chân trang (ví dụ điều khoản thanh toán).
+
+Sau khi chạy lệnh thành công, file PDF báo giá sẽ được tạo tại đường dẫn đã chỉ định trong tham số `--output`.

--- a/quote_app/__init__.py
+++ b/quote_app/__init__.py
@@ -1,0 +1,7 @@
+"""Core package for the quote generation application."""
+
+from .cli import main
+
+__all__ = ["main"]
+
+__version__ = "0.1.0"

--- a/quote_app/cli.py
+++ b/quote_app/cli.py
@@ -1,0 +1,254 @@
+"""Command line interface for generating quotes from product catalogues."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Dict, List, Mapping, Sequence, Tuple
+
+from .data_loader import build_product_index, load_products
+from .template_renderer import build_default_context, render_pdf
+
+ITEM_SPEC_HELP = "Định dạng mỗi sản phẩm: <ma_sp>:<so_luong>, ví dụ SP01:10"
+
+
+def _decimal(value: str) -> Decimal:
+    try:
+        normalised = value.replace(",", ".")
+        return Decimal(normalised)
+    except (InvalidOperation, AttributeError) as exc:
+        raise argparse.ArgumentTypeError(f"Giá trị số không hợp lệ: '{value}'") from exc
+
+
+def _parse_item_spec(spec: str) -> Tuple[str, Decimal]:
+    if ":" not in spec:
+        raise argparse.ArgumentTypeError(
+            f"Định dạng sản phẩm '{spec}' không hợp lệ. Cần dạng <ma_sp>:<so_luong>."
+        )
+    code, quantity_str = spec.split(":", 1)
+    code = code.strip()
+    if not code:
+        raise argparse.ArgumentTypeError(
+            f"Mã sản phẩm rỗng trong tham số '{spec}'."
+        )
+    quantity = _decimal(quantity_str)
+    if quantity <= 0:
+        raise argparse.ArgumentTypeError(
+            f"Số lượng phải lớn hơn 0 trong tham số '{spec}'."
+        )
+    return code, quantity
+
+
+def _build_items(
+    item_specs: Sequence[str],
+    product_index: Mapping[str, Mapping[str, object]],
+) -> Tuple[List[Dict[str, object]], Decimal]:
+    items: List[Dict[str, object]] = []
+    subtotal = Decimal("0")
+    for spec in item_specs:
+        code, quantity = _parse_item_spec(spec)
+        product = product_index.get(code)
+        if not product:
+            raise SystemExit(f"Không tìm thấy sản phẩm với mã '{code}'.")
+
+        unit_price = Decimal(str(product["unit_price"]))
+        line_total = (unit_price * quantity).quantize(Decimal("0.01"))
+        subtotal += line_total
+
+        items.append(
+            {
+                "code": product["code"],
+                "name": product["name"],
+                "description": product.get("description"),
+                "unit": product.get("unit"),
+                "quantity": float(quantity),
+                "unit_price": float(unit_price),
+                "line_total": float(line_total),
+            }
+        )
+    return items, subtotal
+
+
+def _read_template(path: str | None) -> str | None:
+    if not path:
+        return None
+    template_path = Path(path)
+    if not template_path.exists():
+        raise SystemExit(f"Không tìm thấy file mẫu: {template_path}")
+    return template_path.read_text(encoding="utf-8")
+
+
+def _resolve_logo(logo_path: str | None) -> str | None:
+    if not logo_path:
+        return None
+    path = Path(logo_path)
+    if not path.exists():
+        raise SystemExit(f"Không tìm thấy file logo: {path}")
+    return path.resolve().as_uri()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Sinh file báo giá từ danh sách sản phẩm trong Excel.",
+    )
+    parser.add_argument(
+        "--input",
+        required=True,
+        help="Đường dẫn tới file Excel chứa danh sách sản phẩm.",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Đường dẫn file PDF đầu ra.",
+    )
+    parser.add_argument(
+        "--sheet",
+        help="Tên hoặc index của sheet trong Excel (mặc định sheet đầu tiên).",
+    )
+    parser.add_argument(
+        "--template-file",
+        help="File HTML tuỳ chỉnh cho mẫu báo giá.",
+    )
+    parser.add_argument(
+        "--customer",
+        required=True,
+        help="Tên khách hàng hoặc người liên hệ.",
+    )
+    parser.add_argument(
+        "--customer-company",
+        help="Tên công ty của khách hàng (nếu có).",
+    )
+    parser.add_argument(
+        "--customer-address",
+        help="Địa chỉ khách hàng.",
+    )
+    parser.add_argument(
+        "--items",
+        nargs="+",
+        required=True,
+        help=ITEM_SPEC_HELP,
+    )
+    parser.add_argument(
+        "--company-name",
+        default="CÔNG TY TNHH ABC",
+        help="Tên công ty phát hành báo giá.",
+    )
+    parser.add_argument("--company-address", help="Địa chỉ công ty phát hành.")
+    parser.add_argument("--company-phone", help="Số điện thoại công ty.")
+    parser.add_argument("--company-email", help="Email công ty.")
+    parser.add_argument("--company-website", help="Website công ty.")
+    parser.add_argument("--company-tax-code", help="Mã số thuế công ty.")
+    parser.add_argument("--logo", help="Đường dẫn tới file logo hiển thị trên báo giá.")
+    parser.add_argument(
+        "--reference",
+        help="Mã báo giá hoặc số hợp đồng tham chiếu.",
+    )
+    parser.add_argument(
+        "--date",
+        help="Ngày báo giá (mặc định là hôm nay, định dạng DD/MM/YYYY).",
+    )
+    parser.add_argument(
+        "--currency-symbol",
+        default="₫",
+        help="Ký hiệu tiền tệ sử dụng trong báo giá (ví dụ ₫, đ, VND).",
+    )
+    parser.add_argument(
+        "--tax-rate",
+        type=_decimal,
+        help="Tỷ lệ thuế VAT (%). Ví dụ 8 hoặc 10.",
+    )
+    parser.add_argument(
+        "--note",
+        help="Ghi chú thêm ở cuối báo giá. Có thể xuống dòng bằng \n.",
+    )
+    parser.add_argument(
+        "--footer",
+        help="Thông tin chân trang (ví dụ điều khoản thanh toán).",
+    )
+    parser.add_argument(
+        "--base-url",
+        help="Đường dẫn cơ sở cho tài nguyên tĩnh (logo, ảnh).",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    sheet = args.sheet
+    if sheet is not None and sheet.isdigit():
+        sheet = int(sheet)
+
+    products = load_products(args.input, sheet_name=sheet)
+    product_index = build_product_index(products)
+
+    items, subtotal = _build_items(args.items, product_index)
+
+    tax_info = None
+    total = subtotal
+    if args.tax_rate is not None:
+        tax_rate = args.tax_rate
+        tax_amount = (subtotal * tax_rate / Decimal("100")).quantize(Decimal("0.01"))
+        tax_info = {"rate": float(tax_rate), "amount": float(tax_amount)}
+        total = subtotal + tax_amount
+
+    summary = {
+        "subtotal": float(subtotal),
+        "total": float(total),
+    }
+    if tax_info:
+        summary["tax"] = tax_info
+
+    template_content = _read_template(args.template_file)
+    logo_uri = _resolve_logo(args.logo)
+
+    company = {
+        "name": args.company_name,
+        "address": args.company_address,
+        "phone": args.company_phone,
+        "email": args.company_email,
+        "website": args.company_website,
+        "tax_code": args.company_tax_code,
+        "logo": logo_uri,
+    }
+
+    customer = {
+        "name": args.customer,
+        "company": args.customer_company,
+        "address": args.customer_address,
+    }
+
+    quote_date = args.date or datetime.now().strftime("%d/%m/%Y")
+
+    quote = {
+        "date": quote_date,
+        "reference": args.reference,
+        "currency_symbol": args.currency_symbol,
+        "note": args.note,
+    }
+
+    context = build_default_context(
+        company=company,
+        customer=customer,
+        items=items,
+        summary=summary,
+        quote=quote,
+        footer=args.footer,
+    )
+
+    template = template_content if template_content is not None else None
+    base_url = args.base_url
+    if not base_url and args.template_file:
+        base_url = str(Path(args.template_file).resolve().parent)
+
+    if template is None:
+        render_pdf(context, args.output, base_url=base_url)
+    else:
+        render_pdf(context, args.output, template=template, base_url=base_url)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/quote_app/data_loader.py
+++ b/quote_app/data_loader.py
@@ -1,0 +1,114 @@
+"""Utilities for loading product data from spreadsheet files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Iterable, List, Mapping
+
+import pandas as pd
+
+REQUIRED_COLUMNS = {"code", "name", "unit_price"}
+OPTIONAL_COLUMNS = {"unit", "description"}
+
+
+def _normalise_string(value: object) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, float) and pd.isna(value):
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _normalise_number(value: object) -> float:
+    if value is None:
+        raise ValueError("Missing numeric value")
+    if isinstance(value, (int, float)):
+        if pd.isna(value):
+            raise ValueError("Missing numeric value")
+        return float(value)
+
+    text = str(value).strip()
+    if not text:
+        raise ValueError("Missing numeric value")
+    return float(text.replace(",", ""))
+
+
+def load_products(excel_path: str | Path, *, sheet_name: str | int | None = 0) -> List[Dict[str, object]]:
+    """Load products from an Excel file.
+
+    Parameters
+    ----------
+    excel_path:
+        Path to the Excel file containing the product catalogue.
+    sheet_name:
+        Optional Excel sheet name or index. Defaults to the first sheet.
+
+    Returns
+    -------
+    list of dict
+        A list of normalised product dictionaries.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the input file does not exist.
+    ValueError
+        When required columns are missing.
+    """
+
+    path = Path(excel_path)
+    if not path.exists():
+        raise FileNotFoundError(f"Product file not found: {path}")
+
+    dataframe = pd.read_excel(path, sheet_name=sheet_name)
+
+    missing_columns = REQUIRED_COLUMNS - set(dataframe.columns)
+    if missing_columns:
+        raise ValueError(
+            "The product catalogue is missing required columns: "
+            + ", ".join(sorted(missing_columns))
+        )
+
+    dataframe = dataframe.where(~dataframe.isna(), None)
+
+    products: List[Dict[str, object]] = []
+    for row in dataframe.to_dict(orient="records"):
+        product: Dict[str, object] = {}
+        product["code"] = _normalise_string(row.get("code"))
+        product["name"] = _normalise_string(row.get("name"))
+        product["unit_price"] = _normalise_number(row.get("unit_price"))
+
+        if not product["code"] or not product["name"]:
+            raise ValueError("Product entries must include both a code and a name")
+
+        for column in OPTIONAL_COLUMNS:
+            value = _normalise_string(row.get(column))
+            if value is not None:
+                product[column] = value
+
+        extra_data = {
+            key: value
+            for key, value in row.items()
+            if key not in REQUIRED_COLUMNS | OPTIONAL_COLUMNS and value is not None
+        }
+        if extra_data:
+            product["extra"] = extra_data
+
+        products.append(product)
+
+    return products
+
+
+def build_product_index(
+    products: Iterable[Mapping[str, object]], *, key: str = "code"
+) -> Dict[str, Mapping[str, object]]:
+    """Build an index for quick product lookups by product code."""
+
+    index: Dict[str, Mapping[str, object]] = {}
+    for product in products:
+        identifier = product.get(key)
+        if not identifier:
+            continue
+        index[str(identifier)] = product
+    return index

--- a/quote_app/template_renderer.py
+++ b/quote_app/template_renderer.py
@@ -1,0 +1,306 @@
+"""Render HTML and PDF quotes using Jinja2 templates."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Mapping, Sequence
+
+from jinja2 import BaseLoader, Environment, select_autoescape
+
+DEFAULT_TEMPLATE = """
+<!DOCTYPE html>
+<html lang="vi">
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      body {
+        font-family: "DejaVu Sans", "Helvetica", "Arial", sans-serif;
+        color: #1a1a1a;
+        margin: 0;
+        padding: 2.5rem;
+        font-size: 14px;
+        line-height: 1.5;
+      }
+
+      .header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 2rem;
+        border-bottom: 2px solid #004a99;
+        padding-bottom: 1rem;
+      }
+
+      .company-info h1 {
+        margin: 0;
+        font-size: 1.6rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08rem;
+        color: #004a99;
+      }
+
+      .company-info p {
+        margin: 0.1rem 0;
+      }
+
+      .logo img {
+        max-height: 80px;
+      }
+
+      .quote-title {
+        text-align: center;
+        margin: 0;
+        font-size: 1.8rem;
+        letter-spacing: 0.2rem;
+        color: #004a99;
+      }
+
+      .quote-meta {
+        margin: 1.5rem 0;
+      }
+
+      .quote-meta p {
+        margin: 0.2rem 0;
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-top: 1rem;
+      }
+
+      th,
+      td {
+        border: 1px solid #d0d0d0;
+        padding: 0.6rem;
+        vertical-align: top;
+      }
+
+      thead {
+        background-color: #f2f6fb;
+      }
+
+      th {
+        text-transform: uppercase;
+        font-size: 0.78rem;
+        letter-spacing: 0.08rem;
+      }
+
+      .number {
+        text-align: right;
+        white-space: nowrap;
+      }
+
+      .totals {
+        margin-top: 1.5rem;
+        width: 50%;
+        margin-left: auto;
+      }
+
+      .totals td {
+        border: none;
+        padding: 0.3rem 0;
+      }
+
+      .totals td.label {
+        text-align: left;
+      }
+
+      .note {
+        margin-top: 2rem;
+        border-top: 1px solid #d0d0d0;
+        padding-top: 1rem;
+      }
+
+      .footer {
+        margin-top: 3rem;
+        font-size: 0.85rem;
+        color: #555;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="header">
+      <div class="company-info">
+        <h1>{{ company.name }}</h1>
+        {% if company.address %}<p>{{ company.address }}</p>{% endif %}
+        {% if company.phone or company.email %}
+          <p>
+            {% if company.phone %}Điện thoại: {{ company.phone }}{% endif %}
+            {% if company.phone and company.email %} | {% endif %}
+            {% if company.email %}Email: {{ company.email }}{% endif %}
+          </p>
+        {% endif %}
+        {% if company.website %}<p>Website: {{ company.website }}</p>{% endif %}
+        {% if company.tax_code %}<p>MST: {{ company.tax_code }}</p>{% endif %}
+      </div>
+      {% if company.logo %}
+        <div class="logo">
+          <img src="{{ company.logo }}" alt="Logo" />
+        </div>
+      {% endif %}
+    </header>
+
+    <h2 class="quote-title">BÁO GIÁ</h2>
+    <section class="quote-meta">
+      <p><strong>Khách hàng:</strong> {{ customer.name }}</p>
+      {% if customer.company %}<p><strong>Đơn vị:</strong> {{ customer.company }}</p>{% endif %}
+      {% if customer.address %}<p><strong>Địa chỉ:</strong> {{ customer.address }}</p>{% endif %}
+      <p><strong>Ngày báo giá:</strong> {{ quote.date }}</p>
+      {% if quote.reference %}<p><strong>Mã báo giá:</strong> {{ quote.reference }}</p>{% endif %}
+    </section>
+
+    <table>
+      <thead>
+        <tr>
+          <th style="width: 3rem;">STT</th>
+          <th style="width: 7rem;">Mã SP</th>
+          <th>Mô tả</th>
+          <th style="width: 4rem;">ĐVT</th>
+          <th style="width: 5rem;" class="number">Số lượng</th>
+          <th style="width: 7rem;" class="number">Đơn giá</th>
+          <th style="width: 7rem;" class="number">Thành tiền</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for item in items %}
+          <tr>
+            <td class="number">{{ loop.index }}</td>
+            <td>{{ item.code }}</td>
+            <td>
+              <strong>{{ item.name }}</strong>
+              {% if item.description %}<div>{{ item.description }}</div>{% endif %}
+            </td>
+            <td>{{ item.unit or "" }}</td>
+            <td class="number">{{ item.quantity|quantity }}</td>
+            <td class="number">{{ item.unit_price|currency(symbol=quote.currency_symbol) }}</td>
+            <td class="number">{{ item.line_total|currency(symbol=quote.currency_symbol) }}</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+
+    <table class="totals">
+      <tbody>
+        <tr>
+          <td class="label">Tạm tính</td>
+          <td class="number">{{ summary.subtotal|currency(symbol=quote.currency_symbol) }}</td>
+        </tr>
+        {% if summary.tax %}
+          <tr>
+            <td class="label">Thuế ({{ summary.tax.rate }}%)</td>
+            <td class="number">{{ summary.tax.amount|currency(symbol=quote.currency_symbol) }}</td>
+          </tr>
+        {% endif %}
+        <tr>
+          <td class="label"><strong>Tổng cộng</strong></td>
+          <td class="number"><strong>{{ summary.total|currency(symbol=quote.currency_symbol) }}</strong></td>
+        </tr>
+      </tbody>
+    </table>
+
+    {% if quote.note %}
+      <section class="note">
+        <strong>Ghi chú:</strong>
+        <div>{{ quote.note | replace('\n', '<br/>') | safe }}</div>
+      </section>
+    {% endif %}
+
+    {% if footer %}
+      <footer class="footer">{{ footer | replace('\n', '<br/>') | safe }}</footer>
+    {% endif %}
+  </body>
+</html>
+"""
+
+
+def _currency(value: Any, symbol: str = "₫", precision: int | None = None) -> str:
+    if value is None:
+        return ""
+    number = float(value)
+    if precision is None:
+        precision = 0 if number.is_integer() else 2
+    formatted = f"{number:,.{precision}f}"
+    return f"{formatted} {symbol}".strip()
+
+
+def _quantity(value: Any) -> str:
+    if value is None:
+        return ""
+    number = float(value)
+    if number.is_integer():
+        return f"{int(number)}"
+    return f"{number:g}"
+
+
+def _create_environment() -> Environment:
+    env = Environment(
+        loader=BaseLoader(),
+        autoescape=select_autoescape(["html", "xml"]),
+        trim_blocks=True,
+        lstrip_blocks=True,
+    )
+    env.filters["currency"] = _currency
+    env.filters["quantity"] = _quantity
+    return env
+
+
+def render_html(
+    context: Mapping[str, Any], *, template: str = DEFAULT_TEMPLATE
+) -> str:
+    """Render the quote to HTML using the provided context."""
+
+    env = _create_environment()
+    template_obj = env.from_string(template)
+    return template_obj.render(**context)
+
+
+def render_pdf(
+    context: Mapping[str, Any],
+    output_path: str | Path,
+    *,
+    template: str = DEFAULT_TEMPLATE,
+    base_url: str | None = None,
+) -> Path:
+    """Render the quote to a PDF file using WeasyPrint."""
+
+    try:
+        from weasyprint import HTML
+    except ImportError as exc:  # pragma: no cover - informative error path
+        raise RuntimeError(
+            "WeasyPrint is required to export the quote to PDF. "
+            "Install it with `pip install weasyprint`."
+        ) from exc
+
+    html_content = render_html(context, template=template)
+    output = Path(output_path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    HTML(string=html_content, base_url=base_url).write_pdf(str(output))
+    return output
+
+
+def build_default_context(
+    *,
+    company: Mapping[str, Any],
+    customer: Mapping[str, Any],
+    items: Sequence[Mapping[str, Any]],
+    summary: Mapping[str, Any],
+    quote: Mapping[str, Any],
+    footer: str | None = None,
+) -> Dict[str, Any]:
+    """Assemble a full context dictionary for rendering."""
+
+    context: Dict[str, Any] = {
+        "company": company,
+        "customer": customer,
+        "items": items,
+        "summary": summary,
+        "quote": quote,
+        "footer": footer,
+    }
+    if "currency_symbol" not in context["quote"]:
+        context["quote"] = {
+            **context["quote"],
+            "currency_symbol": context["quote"].get("currency_symbol", "₫"),
+        }
+    return context


### PR DESCRIPTION
## Summary
- create a new `quote_app` package with a CLI entry point
- load products from Excel, render a styled HTML quote via Jinja2, and export PDF files with WeasyPrint
- document dependency installation, data preparation, and usage examples in the README

## Testing
- python -m compileall quote_app

------
https://chatgpt.com/codex/tasks/task_e_68ce6f19570c8325b3d68be29d45e779